### PR TITLE
Fixing .gitignore for java project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,24 @@
-/dist/
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*


### PR DESCRIPTION
the last file .gitignore was useless for the project. While this one is the one we actually need.